### PR TITLE
Change button text from 'ADDING...' to 'LOADING...'

### DIFF
--- a/Windows/Config.cs
+++ b/Windows/Config.cs
@@ -42,7 +42,7 @@ namespace BARS.Windows
             {
                 btn_add.Enabled = false;
                 btn_add.Size = new Size(82, 24);
-                btn_add.Text = "ADDING...";
+                btn_add.Text = "LOADING...";
                 await BARS.AddAirport(icao);
                 txt_icao.Clear();
                 txt_icao.Focus();


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of what this PR does -->
Updated loading text in BARS Config window from "ADDING..." to "LOADING...", for after controller adds ICAO code.

## Changes Made
<!-- List the main changes in this pull request -->
- Changed "ADDING..." to "LOADING..." in Windows/Config.cs


## Additional Information
<!-- Any other relevant information, screenshots, or context -->


## Author Information
**Discord Username:** <!-- Your Discord username (if different from GitHub) -->
**VATSIM CID:** <!-- Your VATSIM Controller ID -->

---

### Checklist:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
